### PR TITLE
add selfhosted documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,32 +1,23 @@
 # lf-sample-repository-api-java
 
-Sample maven service app that connects to a Laserfiche Cloud Repository using a service principal account.
+Sample maven service app that connects to a Laserfiche Cloud Repository using a service principal account or Self-Hosted Repository.
 [Sample Code](./src/main/java/sample/Sample.java)
 
-## Prerequisites
+## Cloud Prerequisites
 
 ### Software Prerequisites
 
 - Apache Maven 3.8.5+
 - Java 8+
-
-### Cloud Prerequisites
-
 - CA, EU, or US Cloud Web Client account
-
-### Self Hosted Prerequisites
-
-- Set up Self Hosted API Server 1.0.0.40+
-
-**Note:** If you are running the sample project against a self hosted API server, then skip to **[step 3](#3-clone-this-repo-on-your-local-machine)**
 
 ### 1. Create a Service Principal
 
 - Log in to your account using Web Client as an administrator:
 
-    - [CA Cloud](https://app.laserfiche.ca/laserfiche)
-    - [EU Cloud](https://app.eu.laserfiche.com/laserfiche)
-    - [US Cloud](https://app.laserfiche.com/laserfiche)
+  - [CA Cloud](https://app.laserfiche.ca/laserfiche)
+  - [EU Cloud](https://app.eu.laserfiche.com/laserfiche)
+  - [US Cloud](https://app.laserfiche.com/laserfiche)
 
 - Using the app picker, go to the 'Account' page
 - Click on the 'Service Principals' tab
@@ -38,9 +29,9 @@ Sample maven service app that connects to a Laserfiche Cloud Repository using a 
 ### 2. Create an OAuth Service App
 
 - Navigate to Laserfiche Developer Console:
-    - [CA Cloud](https://app.laserfiche.ca/devconsole/)
-    - [EU Cloud](https://app.eu.laserfiche.com/devconsole/)
-    - [US Cloud](https://app.laserfiche.com/devconsole/)
+  - [CA Cloud](https://app.laserfiche.ca/devconsole/)
+  - [EU Cloud](https://app.eu.laserfiche.com/devconsole/)
+  - [US Cloud](https://app.laserfiche.com/devconsole/)
 - Click on the 'New' button and choose the 'Create a new app' option
 - Select the 'Service' option, enter a name, and click the 'Create application' button
 - Select the app service account to be the one created on step 1 and click the 'Save changes' button
@@ -50,8 +41,6 @@ Sample maven service app that connects to a Laserfiche Cloud Repository using a 
 ### 3. Clone this repo on your local machine
 
 ### 4. Create a .env file
-
-#### If running this sample project against Cloud 
 
 - Using the app picker, go to the 'Repository Administration' page and copy the Repository ID
 - In the root directory of this project, create a .env file containing the following lines:
@@ -64,8 +53,20 @@ ACCESS_KEY="<base-64 Access Key string created from step 2>"
 
 REPOSITORY_ID="<Repository ID from the 'Repository Administration' page>"
 ```
+- Note: The .env file is used in local development environment to set operating system environment variables. DO NOT
+  check-in the .env file in Git
 
-#### If running this sample project against Self-Hosted
+## Self-Hosted Prerequisites
+
+### Software Prerequisites
+
+- Apache Maven 3.8.5+
+- Java 8+
+- Set up Self-Hosted API Server 1.0+
+
+### 1. Clone this repo on your local machine
+
+### 2. Create a .env file
 
 - In the root directory of this project, create a .env file containing the following lines:
 
@@ -78,7 +79,7 @@ APISERVER_USERNAME="<Username>"
 
 APISERVER_PASSWORD="<Password>"
 
-APISERVER_REPOSITORY_API_BASE_URL="<API Server Host Name>"
+APISERVER_REPOSITORY_API_BASE_URL="<API Server Host Name (ex: https://example.com/LFRepositoryAPI)>"
 ```
 - Note: The .env file is used in local development environment to set operating system environment variables. DO NOT
   check-in the .env file in Git

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Sample maven service app that connects to a Laserfiche Cloud Repository using a 
 ### 3. Clone this repo on your local machine
 
 ### 4. Create a .env file
-
+#### If running this sample project against Cloud 
 - Using the app picker, go to the 'Repository Administration' page and copy the Repository ID
 - In the root directory of this project, create a .env file containing the following lines:
 
@@ -53,7 +53,20 @@ ACCESS_KEY="<base-64 Access Key string created from step 2>"
 
 REPOSITORY_ID="<Repository ID from the 'Repository Administration' page>"
 ```
+#### If running this sample project against Self-Hosted
+- In the root directory of this project, create a .env file containing the following lines:
 
+```
+AUTHORIZATION_TYPE="API_SERVER_USERNAME_PASSWORD" 
+
+REPOSITORY_ID="<Repository Name>"
+
+APISERVER_USERNAME="<Username>"
+
+APISERVER_PASSWORD="<Password>"
+
+APISERVER_REPOSITORY_API_BASE_URL="<APIserver Host Name>"
+```
 - Note: The .env file is used in local development environment to set operating system environment variables. DO NOT
   check-in the .env file in Git
 
@@ -70,5 +83,5 @@ java -jar target/lf-sample-repository-api-1.0-0-jar-with-dependencies.jar
 These commands will install, compile, and execute this program which will print out the repository information in the
 output window.
 Note: This project uses the [@laserfiche/lf-repository-api-client
-Maven Central package](insert link here).
+Maven Central package](https://central.sonatype.dev/artifact/com.laserfiche/lf-repository-api-client/1.1.1).
 See [Laserfiche Repository API Documentation](https://developer.laserfiche.com/libraries.html).

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ APISERVER_USERNAME="<Username>"
 
 APISERVER_PASSWORD="<Password>"
 
-APISERVER_REPOSITORY_API_BASE_URL="<API Server Host Name (ex: https://example.com/LFRepositoryAPI)>"
+APISERVER_REPOSITORY_API_BASE_URL="<API Server Base Url (ex: https://example.com/LFRepositoryAPI)>"
 ```
 - Note: The .env file is used in local development environment to set operating system environment variables. DO NOT
   check-in the .env file in Git

--- a/README.md
+++ b/README.md
@@ -12,13 +12,13 @@ Sample maven service app that connects to a Laserfiche Cloud Repository using a 
 
 ### Cloud Prerequisites
 
-- CA, EU, or US Cloud Web Client Account
+- CA, EU, or US Cloud Web Client account
 
 ### Self Hosted Prerequisites
 
-- Set up Self Hosted Api Server 1.0.0.40+
+- Set up Self Hosted API Server 1.0.0.40+
 
-**Note:** If you are running the sample project against a self hosted api server, then skip to **[step 3](#3-clone-this-repo-on-your-local-machine)**
+**Note:** If you are running the sample project against a self hosted API server, then skip to **[step 3](#3-clone-this-repo-on-your-local-machine)**
 
 ### 1. Create a Service Principal
 
@@ -50,10 +50,11 @@ Sample maven service app that connects to a Laserfiche Cloud Repository using a 
 ### 3. Clone this repo on your local machine
 
 ### 4. Create a .env file
+
 #### If running this sample project against Cloud 
+
 - Using the app picker, go to the 'Repository Administration' page and copy the Repository ID
 - In the root directory of this project, create a .env file containing the following lines:
-
 ```
 AUTHORIZATION_TYPE="CLOUD_ACCESS_KEY" 
 
@@ -63,7 +64,9 @@ ACCESS_KEY="<base-64 Access Key string created from step 2>"
 
 REPOSITORY_ID="<Repository ID from the 'Repository Administration' page>"
 ```
+
 #### If running this sample project against Self-Hosted
+
 - In the root directory of this project, create a .env file containing the following lines:
 
 ```
@@ -75,15 +78,15 @@ APISERVER_USERNAME="<Username>"
 
 APISERVER_PASSWORD="<Password>"
 
-APISERVER_REPOSITORY_API_BASE_URL="<Api Server Host Name>"
+APISERVER_REPOSITORY_API_BASE_URL="<API Server Host Name>"
 ```
 - Note: The .env file is used in local development environment to set operating system environment variables. DO NOT
   check-in the .env file in Git
 
 ## Build and Run this App
 
-- Open with IntelliJ
-- On a terminal window, enter the following commands:
+- Open a terminal window
+- Enter the following commands:
 
 ```maven
 mvn clean compile assembly:single

--- a/README.md
+++ b/README.md
@@ -10,6 +10,16 @@ Sample maven service app that connects to a Laserfiche Cloud Repository using a 
 - Apache Maven 3.8.5+
 - Java 8+
 
+### Cloud Prerequisites
+
+- CA, EU, or US Cloud Web Client Account
+
+### Self Hosted Prerequisites
+
+- Set up Self Hosted Api Server 1.0.0.40+
+
+**Note:** If you are running the sample project against a self hosted api server, then skip to **[step 3](#3-clone-this-repo-on-your-local-machine)**
+
 ### 1. Create a Service Principal
 
 - Log in to your account using Web Client as an administrator:
@@ -65,7 +75,7 @@ APISERVER_USERNAME="<Username>"
 
 APISERVER_PASSWORD="<Password>"
 
-APISERVER_REPOSITORY_API_BASE_URL="<APIserver Host Name>"
+APISERVER_REPOSITORY_API_BASE_URL="<Api Server Host Name>"
 ```
 - Note: The .env file is used in local development environment to set operating system environment variables. DO NOT
   check-in the .env file in Git

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # lf-sample-repository-api-java
 
-Sample maven service app that connects to a Laserfiche Cloud Repository using a service principal account or Self-Hosted Repository.
+Sample maven service app that connects to a Laserfiche Cloud Repository or Self-Hosted Repository.
 [Sample Code](./src/main/java/sample/Sample.java)
 
 ## Cloud Prerequisites

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # lf-sample-repository-api-java
 
-Sample maven service app that connects to a Laserfiche Cloud Repository or Self-Hosted Repository.
+Sample maven service app that connects to a Laserfiche Cloud or Self-Hosted Repository.
 [Sample Code](./src/main/java/sample/Sample.java)
 
 ## Cloud Prerequisites


### PR DESCRIPTION
Add documentation in each github repo explaining how to configure it for self hosted for all service sample apps
Linked the published Java Repo Client Maven Central 