### PR TITLE
Support autocloseable

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -62,12 +62,12 @@
         <dependency>
             <groupId>com.laserfiche</groupId>
             <artifactId>lf-api-client-core</artifactId>
-            <version>1.0.0</version>
+            <version>1.1.0</version>
         </dependency>
         <dependency>
             <groupId>com.laserfiche</groupId>
             <artifactId>lf-repository-api-client</artifactId>
-            <version>1.1.0</version>
+            <version>1.2.0</version>
         </dependency>
     </dependencies>
 

--- a/src/main/java/sample/Sample.java
+++ b/src/main/java/sample/Sample.java
@@ -25,7 +25,7 @@ public class Sample {
         CompletableFuture
                 .allOf(getRepositoryInfo(), getRootFolder(), getFolderChildren(ROOT_FOLDER_ENTRY_ID))
                 .join();
-        System.exit(0);
+        client.close();
     }
 
     public static CompletableFuture<RepositoryInfo[]> getRepositoryInfo() {


### PR DESCRIPTION
We used to use `System.exit(0)` because the underlying HTTP client doesn't release its thread pool. We now support AutoCloseable both in the client core and repository client libraries (two dependencies of this project), so we can now use AutoCloseable API to release such resource. In this PR, we updated the code to use AutoCloseable.