### PR TITLE
change sonatype snapshot to maven central dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,5 +99,5 @@ java -jar target/lf-sample-repository-api-1.0.0-jar-with-dependencies.jar
 These commands will install, compile, and execute this program which will print out the repository information in the
 output window.
 Note: This project uses the [@laserfiche/lf-repository-api-client
-Maven Central package](https://s01.oss.sonatype.org/content/repositories/snapshots/com/laserfiche/lf-repository-api-client/2.0.0-preview-4406822515-SNAPSHOT/).
+Maven Central package](https://central.sonatype.com/artifact/com.laserfiche/lf-repository-api-client/2.0.2).
 See [Laserfiche Repository API Documentation](https://developer.laserfiche.com/libraries.html).

--- a/pom.xml
+++ b/pom.xml
@@ -62,12 +62,12 @@
         <dependency>
             <groupId>com.laserfiche</groupId>
             <artifactId>lf-api-client-core</artifactId>
-            <version>2.2.0-preview-4406822515-SNAPSHOT</version>
+            <version>2.2.0</version>
         </dependency>
         <dependency>
             <groupId>com.laserfiche</groupId>
             <artifactId>lf-repository-api-client</artifactId>
-            <version>2.0.0-preview-4406822515-SNAPSHOT</version>
+            <version>2.0.2</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
- changed sonatype snapshot dependencies to maven central dependencies in the `pom.xml` file
- updated java repo client link in the README.md file